### PR TITLE
adding alt tag when preloading images

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -282,7 +282,10 @@
       var windowHeight;
       var windowWidth;
 
-      $image.attr('src', self.album[imageNumber].link);
+      $image.attr({
+        'src': self.album[imageNumber].link,
+        'alt': self.album[imageNumber].title
+      });
 
       $preloader = $(preloader);
 


### PR DESCRIPTION
the current lb2 implementation does not create an alt-tag for the image. Alt tags are required for image tags.